### PR TITLE
Refactor layout and clean configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,7 +8,6 @@ const nextConfig = {
     deviceSizes: [320, 375, 414, 768, 1024, 1200],
     imageSizes: [16, 32, 48, 64, 96, 128, 256],
   },
-  swcMinify: true,
   reactStrictMode: true,
   compress: true,
   poweredByHeader: false,
@@ -16,7 +15,6 @@ const nextConfig = {
   // Performance optimizations
   experimental: {
     optimizePackageImports: ['react-icons', 'lucide-react'],
-    swcMinify: true,
     cpus: 1, // Optimize for mobile builds
   },
   

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "detektive",
+  "name": "detektiv",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "detektive",
+      "name": "detektiv",
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "detektive",
+  "name": "detektiv",
   "version": "0.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
     "prebuild": "node scripts/generate-translations.js",
     "build": "next build",
-    "start": "next build && npx serve@latest out",
+    "start": "npx serve@latest out",
     "lint": "next lint",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/scripts/generate-translations.js
+++ b/scripts/generate-translations.js
@@ -1,30 +1,34 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
+const fs = require('fs/promises');
 const path = require('path');
 const matter = require('gray-matter');
 
-/**
- * Автогенератор переводов из файловой структуры
- * Сканирует /data/stati/ и /data/blog/ для создания translatedPosts.json
- */
+// Автогенератор переводов из файловой структуры
+// Сканирует /data/stati/ и /data/blog/ для создания translatedPosts.json
 
 const STATI_DIR = path.join(__dirname, '../src/data/stati');
 const BLOG_DIR = path.join(__dirname, '../src/data/blog');
 const OUTPUT_FILE = path.join(__dirname, '../src/data/translatedPosts.json');
 
-/**
- * Извлекает slug из frontmatter файла
- */
-function extractSlugFromFile(filePath) {
+async function fileExists(p) {
   try {
-    if (!fs.existsSync(filePath)) {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function extractSlugFromFile(filePath) {
+  try {
+    if (!(await fileExists(filePath))) {
       return null;
     }
-    
-    const fileContent = fs.readFileSync(filePath, 'utf8');
+
+    const fileContent = await fs.readFile(filePath, 'utf8');
     const { data } = matter(fileContent);
-    
+
     return data.slug || null;
   } catch (error) {
     console.warn(`⚠️  Ошибка чтения файла ${filePath}:`, error.message);
@@ -32,103 +36,95 @@ function extractSlugFromFile(filePath) {
   }
 }
 
-/**
- * Получает список номеров файлов из директории
- */
-function getFileNumbers(directory) {
-  if (!fs.existsSync(directory)) {
+async function getFileNumbers(directory) {
+  if (!(await fileExists(directory))) {
     console.warn(`⚠️  Директория не найдена: ${directory}`);
     return [];
   }
-  
-  return fs.readdirSync(directory)
+
+  const files = await fs.readdir(directory);
+
+  return files
     .filter(file => file.endsWith('.md'))
-    .map(file => parseInt(file.replace('.md', '')))
+    .map(file => parseInt(file.replace('.md', ''), 10))
     .filter(num => !isNaN(num))
     .sort((a, b) => a - b);
 }
 
-/**
- * Генерирует объект перевода для пары файлов
- */
-function generateTranslationPair(fileNumber) {
+async function generateTranslationPair(fileNumber) {
   const ruFile = path.join(STATI_DIR, `${fileNumber}.md`);
   const enFile = path.join(BLOG_DIR, `${fileNumber}.md`);
-  
-  const ruSlug = extractSlugFromFile(ruFile);
-  const enSlug = extractSlugFromFile(enFile);
-  
+
+  const [ruSlug, enSlug] = await Promise.all([
+    extractSlugFromFile(ruFile),
+    extractSlugFromFile(enFile),
+  ]);
+
   if (!ruSlug || !enSlug) {
     console.warn(`⚠️  Отсутствует slug для файла ${fileNumber}: ru=${ruSlug}, en=${enSlug}`);
     return null;
   }
-  
+
   return {
     en: enSlug,
-    ru: ruSlug
+    ru: ruSlug,
   };
 }
 
-/**
- * Основная функция генерации
- */
-function generateTranslations() {
+async function generateTranslations() {
   console.log('🔄 Генерация переводов из файловой структуры...');
-  
-  // Получаем списки файлов из обеих директорий
-  const ruNumbers = getFileNumbers(STATI_DIR);
-  const enNumbers = getFileNumbers(BLOG_DIR);
-  
+
+  const [ruNumbers, enNumbers] = await Promise.all([
+    getFileNumbers(STATI_DIR),
+    getFileNumbers(BLOG_DIR),
+  ]);
+
   console.log(`📊 Найдено файлов: stati=${ruNumbers.length}, blog=${enNumbers.length}`);
-  
-  // Находим пересечение - файлы, которые есть в обеих директориях
+
   const commonNumbers = ruNumbers.filter(num => enNumbers.includes(num));
-  
+
   console.log(`🔗 Файлов с переводами: ${commonNumbers.length}`);
-  
+
   if (commonNumbers.length === 0) {
     console.warn('⚠️  Не найдено файлов с переводами');
     return;
   }
-  
-  // Генерируем пары переводов
+
   const translations = [];
-  
+
   for (const fileNumber of commonNumbers) {
-    const pair = generateTranslationPair(fileNumber);
+    const pair = await generateTranslationPair(fileNumber);
     if (pair) {
       translations.push(pair);
       console.log(`✅ ${fileNumber}.md: ${pair.ru} ↔ ${pair.en}`);
     }
   }
-  
+
   if (translations.length === 0) {
     console.error('❌ Не удалось сгенерировать ни одного перевода');
     process.exit(1);
   }
-  
-  // Записываем результат
+
   const outputContent = JSON.stringify(translations, null, 2);
-  fs.writeFileSync(OUTPUT_FILE, outputContent, 'utf8');
-  
+  await fs.writeFile(OUTPUT_FILE, outputContent, 'utf8');
+
   console.log(`🎉 Успешно сгенерировано ${translations.length} переводов в ${OUTPUT_FILE}`);
-  
-  // Показываем статистику
+
   const orphanedRu = ruNumbers.filter(num => !commonNumbers.includes(num));
   const orphanedEn = enNumbers.filter(num => !commonNumbers.includes(num));
-  
+
   if (orphanedRu.length > 0) {
     console.log(`📝 Файлы без перевода (только русские): ${orphanedRu.join(', ')}`);
   }
-  
+
   if (orphanedEn.length > 0) {
     console.log(`📝 Файлы без перевода (только английские): ${orphanedEn.join(', ')}`);
   }
 }
 
-// Запускаем генерацию
 if (require.main === module) {
   generateTranslations();
 }
 
 module.exports = { generateTranslations };
+

--- a/src/app/(en)/layout.tsx
+++ b/src/app/(en)/layout.tsx
@@ -1,27 +1,5 @@
-import '@/app/globals.css';
-import { inter, playfairDisplay } from '@/app/fonts';
-import Body from '@/components/layout/body';
-import { Props } from '@/components/utility/types';
-import CommonHead from '@/components/layout/CommonHead';
-import metadataConfig from '@/data/metadata.json';
+import { createMetadata, createRootLayout } from '@/components/layout/createRootLayout';
 
-export const metadata = {
-  title: metadataConfig.en.title,
-  description: metadataConfig.en.description,
-  keywords: metadataConfig.en.keywords,
-};
+export const metadata = createMetadata('en');
 
-export default function RootLayout({ children }: Props) {
-  const lang = 'en';
-
-  return (
-    <html lang={lang} className={`${inter.variable} ${playfairDisplay.variable}`}>
-      <head>
-        <CommonHead />
-      </head>
-      <Body lang={lang} showHero={true}>
-        {children}
-      </Body>
-    </html>
-  );
-}
+export default createRootLayout('en');

--- a/src/app/(ru)/layout.tsx
+++ b/src/app/(ru)/layout.tsx
@@ -1,27 +1,5 @@
-import '@/app/globals.css';
-import { inter, playfairDisplay } from '@/app/fonts';
-import { Props } from '@/components/utility/types';
-import Body from '@/components/layout/body';
-import CommonHead from '@/components/layout/CommonHead';
-import metadataConfig from '@/data/metadata.json';
+import { createMetadata, createRootLayout } from '@/components/layout/createRootLayout';
 
-export const metadata = {
-  title: metadataConfig.ru.title,
-  description: metadataConfig.ru.description,
-  keywords: metadataConfig.ru.keywords,
-};
+export const metadata = createMetadata('ru');
 
-export default function RootLayout({ children }: Props) {
-  const lang = 'ru';
-
-  return (
-    <html lang={lang} className={`${inter.variable} ${playfairDisplay.variable}`}>
-      <head>
-        <CommonHead />
-      </head>
-      <Body lang={lang} showHero={true}>
-        {children}
-      </Body>
-    </html>
-  );
-}
+export default createRootLayout('ru');

--- a/src/components/layout/createRootLayout.tsx
+++ b/src/components/layout/createRootLayout.tsx
@@ -1,0 +1,33 @@
+import '@/app/globals.css';
+import { inter, playfairDisplay } from '@/app/fonts';
+import Body from '@/components/layout/body';
+import CommonHead from '@/components/layout/CommonHead';
+import { Props } from '@/components/utility/types';
+import metadataConfig from '@/data/metadata.json';
+
+type Lang = keyof typeof metadataConfig;
+
+export const createMetadata = (lang: Lang) => {
+  const config = (metadataConfig as Record<Lang, { title: string; description: string; keywords: string }>)[lang];
+  return {
+    title: config.title,
+    description: config.description,
+    keywords: config.keywords,
+  };
+};
+
+export const createRootLayout = (lang: Lang) => {
+  return function RootLayout({ children }: Props) {
+    return (
+      <html lang={lang} className={`${inter.variable} ${playfairDisplay.variable}`}>
+        <head>
+          <CommonHead />
+        </head>
+        <Body lang={lang} showHero={true}>
+          {children}
+        </Body>
+      </html>
+    );
+  };
+};
+


### PR DESCRIPTION
## Summary
- remove redundant swcMinify settings from Next.js config
- align package name and simplify start script
- deduplicate locale layouts via a shared factory
- rewrite translation generator to use async fs/promises

## Testing
- `npm test`
- `npx eslint .` *(fails: Unexpected any, no-case-declarations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68962e63bd308327adf0f5cf6c863f65