### PR TITLE
fix: allow CommonJS in offline validator

### DIFF
--- a/scripts/offline-validate.js
+++ b/scripts/offline-validate.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-require-imports */
 /**
  * Offline link validator for static export in `out/`.
  *
@@ -72,7 +73,7 @@ function resolveCandidates(currentHtmlRel, url) {
   let decoded = cleaned;
   try {
     decoded = decodeURIComponent(cleaned);
-  } catch (_) {
+  } catch {
     // ignore decoding errors; fall back to original
     decoded = cleaned;
   }


### PR DESCRIPTION
## Summary
- silence ESLint no-require-imports rule for offline link validator
- remove unused catch binding in offline validator

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68985292e3488327a6d1facd6ade7e21