### PR TITLE
Fix test script and resolve DOM nesting warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint . --cache --cache-location .eslintcache",
     "lint:fix": "eslint . --fix --cache --cache-location .eslintcache",
     "test:unit": "jest",
-    "test": "npm run test:unit && npm run test:e2e:run",
+    "test": "npm run build && npm run test:unit && npm run test:e2e:run",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:e2e": "npm run build && playwright test",

--- a/src/components/ui/contactButtons.tsx
+++ b/src/components/ui/contactButtons.tsx
@@ -37,10 +37,10 @@ export default function ContactButtons({ lang, proposeText }: ContactButtonsProp
       </div>
 
       <div className="mt-8 p-6 bg-white rounded-xl border border-primary-200">
-        <p className="text-heading-sm font-semibold text-primary-600 mb-2 flex items-center justify-center gap-2">
+        <div className="text-heading-sm font-semibold text-primary-600 mb-2 flex items-center justify-center gap-2">
           <IconSvg name="phone" size="sm" color="current" className="w-5 h-5" />
           {lang === 'ru' ? 'Бесплатная консультация' : 'Free Consultation'}
-        </p>
+        </div>
         <p className="text-body-md text-secondary-600">
           {lang === 'ru' 
             ? 'Обсудим ваш случай и подберем оптимальное решение' 


### PR DESCRIPTION
This commit addresses two issues found during a code cleanup:

1.  The `test` script in `package.json` was missing the `build` step. This caused E2E tests to fail because the Playwright web server could not find the `out` directory to serve. The script has been updated to run the build before the tests.

2.  A `validateDOMNesting` warning was present in unit tests due to a `<div>` being rendered inside a `<p>` tag within the `ContactButtons` component. The `<p>` tag has been changed to a `<div>` to ensure the HTML is semantically correct.