### PR TITLE
test(e2e): Refactor navigation tests to improve reliability

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -6,16 +6,18 @@ test.describe('Navigation', () => {
     await page.goto('/');
 
     const pagesPart1 = [
-      { name: /о нас|about/i, url: /onas|about/ },
-      { name: /цены|price/i, url: /price/ },
-      { name: /контакты|contact/i, url: /kontakty|contact/ },
+      { name: /о нас|about/i, url: '/onas' },
+      { name: /цены|price/i, url: '/price' },
+      { name: /контакты|contact/i, url: '/kontakty' },
     ];
 
     for (const pageInfo of pagesPart1) {
       await clickNavLink(page, { name: pageInfo.name, url: pageInfo.url });
+      await expect(page).toHaveURL(pageInfo.url);
       await expect(page.locator('main#main-content')).toBeVisible();
       // Go back to home via client-side navigation instead of a hard reload
-      await clickNavLink(page, { name: /главная|main/i, url: /(^\/$)|(^\/en$)/ });
+      await clickNavLink(page, { name: /главная|main/i, url: '/' });
+      await expect(page).toHaveURL('/');
     }
   });
 
@@ -23,16 +25,18 @@ test.describe('Navigation', () => {
     await page.goto('/');
 
     const pagesPart2 = [
-      { name: /статьи|blog/i, url: /stati|blog/ },
-      { name: /вакансии|job/i, url: /vakansii|job/ },
-      { name: /гарантии|guarantee/i, url: /garantii|guarantee/ },
+      { name: /статьи|blog/i, url: '/stati' },
+      { name: /вакансии|job/i, url: '/vakansii' },
+      { name: /гарантии|guarantee/i, url: '/garantii' },
     ];
 
     for (const pageInfo of pagesPart2) {
       await clickNavLink(page, { name: pageInfo.name, url: pageInfo.url });
+      await expect(page).toHaveURL(pageInfo.url);
       await expect(page.locator('main#main-content')).toBeVisible();
       // Go back to home via client-side navigation instead of a hard reload
-      await clickNavLink(page, { name: /главная|main/i, url: /(^\/$)|(^\/en$)/ });
+      await clickNavLink(page, { name: /главная|main/i, url: '/' });
+      await expect(page).toHaveURL('/');
     }
   });
 

--- a/e2e/utils/nav.ts
+++ b/e2e/utils/nav.ts
@@ -27,99 +27,10 @@ export async function ensurePrimaryNav(page: Page): Promise<Locator> {
 
 export async function clickNavLink(
   page: Page,
-  opts: { name: RegExp; url: RegExp }
+  opts: { name: RegExp; url: string }
 ): Promise<void> {
-  await page.waitForLoadState('domcontentloaded');
-  let nav = await ensurePrimaryNav(page);
-  let link = nav.getByRole('link', { name: opts.name }).first();
-
-  // Если в текущем nav ссылка не найдена (например, выбрали не тот nav), пробуем альтернативы
-  if (await link.count() === 0) {
-    // Попробуем открыть мобильное меню и поискать там, если оно закрыто
-    const mobileButton = page.locator('button.hamburger-btn').first();
-    const mobileMenu = page.locator('#mobile-menu');
-    const isMenuOpen = (await mobileMenu.getAttribute('aria-hidden')) === 'false' || (await mobileButton.getAttribute('aria-expanded')) === 'true';
-    if (await mobileButton.isVisible() && !isMenuOpen) {
-      await mobileButton.click();
-      await expect(mobileMenu).toBeVisible();
-    }
-    if (await mobileMenu.isVisible()) {
-      nav = mobileMenu.getByRole('navigation', { name: /мобильная навигация|mobile navigation/i });
-      link = nav.getByRole('link', { name: opts.name }).first();
-    }
-  }
-
-  // В крайнем случае ищем ссылку по всей странице
-  if (await link.count() === 0) {
-    link = page.getByRole('link', { name: opts.name }).first();
-  }
-
-  // Если по имени не нашли/не видно — пробуем найти по href, совпадающему с ожидаемым URL
-  if (await link.count() === 0 || !(await link.isVisible())) {
-    // Если открыто мобильное меню — не ищем по всей странице, чтобы не кликнуть сквозь оверлей
-    const mobileMenu = page.locator('#mobile-menu');
-    const isMenuOpen = (await mobileMenu.getAttribute('aria-hidden')) === 'false';
-    const searchScopes: Locator[] = isMenuOpen ? [nav] : [nav, page.locator('body')];
-    for (const scope of searchScopes) {
-      const anchors = scope.locator('a[href]');
-      const total = await anchors.count();
-      for (let i = 0; i < total; i++) {
-        const cand = anchors.nth(i);
-        const href = await cand.getAttribute('href');
-        if (href && opts.url.test(href)) {
-          link = cand;
-          i = total; // break inner loop
-          break;
-        }
-      }
-      if (await link.count()) break;
-    }
-  }
-
+  const nav = await ensurePrimaryNav(page);
+  const link = nav.getByRole('link', { name: opts.name }).first();
   await expect(link).toBeVisible();
-  await link.scrollIntoViewIfNeeded();
-  const prevUrl = page.url();
-  const hrefCandidate = await link.getAttribute('href');
-  // Ensure internal links open in the same tab to avoid new pages
-  try {
-    if (hrefCandidate && /^\//.test(hrefCandidate)) {
-      await link.evaluate((el) => {
-        const a = el as HTMLAnchorElement;
-        if (a && a.target === '_blank') a.target = '_self';
-      });
-    }
-  } catch {
-    // Intentionally ignore non-fatal DOM exceptions (lint: no-empty)
-    void 0;
-  }
-
-  // Пытаемся кликнуть быстро; при проблемах (оверлей/неактуален) перейдём через goto
-  try {
-    // In Firefox, waiting for navigation can stall on SPA routes; click fast.
-    await link.click({ noWaitAfter: true, timeout: 2000 });
-  } catch (clickErr) {
-    if (hrefCandidate && /^\//.test(hrefCandidate)) {
-      await page.goto(hrefCandidate);
-      await expect(page).toHaveURL(opts.url);
-      return;
-    }
-    throw clickErr;
-  }
-
-  // Quick check for URL change; if not changed quickly, force navigation
-  const changedQuickly = await page
-    .waitForFunction((u) => location.href !== u, prevUrl, { timeout: 5000 })
-    .then(() => true)
-    .catch(() => false);
-
-  if (!changedQuickly && hrefCandidate && /^\//.test(hrefCandidate)) {
-    await page.goto(hrefCandidate);
-    await expect(page).toHaveURL(opts.url);
-    await page.waitForSelector('main#main-content', { state: 'attached', timeout: 15000 });
-    return;
-  }
-
-  await expect(page).toHaveURL(opts.url);
-  // Ensure main content is attached after client-side navigation
-  await page.waitForSelector('main#main-content', { state: 'attached', timeout: 15000 });
+  await link.click();
 }


### PR DESCRIPTION
The e2e navigation tests were failing due to two main issues:
1.  Incorrect use of regex in `toHaveURL` assertions, which was causing failures when comparing against the full page URL.
2.  Overly complex and fragile navigation logic in the `clickNavLink` helper function, which led to timeouts and race conditions.

This commit addresses these issues by:
-   Replacing the regex-based URL matching with simple string path matching in `e2e/navigation.spec.ts`.
-   Simplifying the `clickNavLink` helper in `e2e/utils/nav.ts` to be a straightforward "find and click" function.
-   Moving the URL and content assertions from the helper into the test files themselves, making the tests more explicit and easier to debug.